### PR TITLE
Add IoC Container example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Now you can visit [http://localhost:8000/](http://localhost:8000/) in your brows
  * [Support](https://github.com/mattstauffer/IlluminateSlim/tree/master/public/support)
  * [Cache](https://github.com/mattstauffer/IlluminateSlim/tree/master/public/cache)
  * [Config](https://github.com/mattstauffer/IlluminateSlim/tree/master/public/config)
+ * [IoC Container](https://github.com/mattstauffer/IlluminateSlim/tree/master/public/container)
 
 ### Planned
  * Session
  * Pagination
- * IOC
  * Routing
  * HTTP
  * Queue

--- a/public/container/index.php
+++ b/public/container/index.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * Illuminate/Container is a powerful inversion of control container,
+ * which can easily be used independent of Laravel to help manage
+ * class dependencies. In addition to basic class binding, it
+ * also supports automatic resolution, which resolves classes
+ * without any configuration required.
+ *
+ * Requires: illuminate/container
+ *
+ * @source https://github.com/illuminate/container
+ */
+
+/*
+|--------------------------------------------------------------------------
+| Bootstrap
+|--------------------------------------------------------------------------
+*/
+
+// Include project libraries, including a number of mock
+// examples of common, real-world services
+require_once '../../vendor/autoload.php';
+require_once 'libraries/Authentication.php';
+require_once 'libraries/Controller.php';
+require_once 'libraries/Database.php';
+require_once 'libraries/Mailer.php';
+require_once 'libraries/Template.php';
+
+// Create new IoC Container instance
+$container = new Illuminate\Container\Container;
+
+// Bind a "template" class to the container
+$container->bind('template', 'Acme\Template');
+
+// Bind a "mailer" class to the container
+// Use a callback to set additional settings
+$container->bind('mailer', function ($container) {
+
+	$mailer = new Acme\Mailer;
+	$mailer->username = 'username';
+	$mailer->password = 'password';
+	$mailer->from = 'foo@bar.com';
+
+	return $mailer;
+});
+
+// Bind a shared "database" class to the container
+// Use a callback to set additional settings
+$container->singleton('database', function ($container) {
+
+	return new Acme\Database('username', 'password', 'host', 'database');
+});
+
+// Bind an existing "authentication" class instance to the container
+$auth = new Acme\Authentication;
+$container->instance('auth', $auth);
+
+
+/*
+|--------------------------------------------------------------------------
+| Routes
+|--------------------------------------------------------------------------
+*/
+
+$app = new \Slim\Slim();
+
+$app->get('/', function () use ($container) {
+
+	// Create new Acme\Template instance
+	$template = $container->make('template');
+
+	// Render template
+	echo $template->render('home');
+});
+
+$app->get('/send-email', function () use ($container) {
+
+	// Create new Acme\Mailer instance
+	$mailer = $container->make('mailer');
+
+	// Set mail settings
+	$mailer->to = 'foo@bar.com';
+	$mailer->subject = 'Test email';
+	$mailer->body = 'This is a test email.';
+
+	// Send the email
+	if ($mailer->send()) {
+		echo 'Email successfully sent!';
+	}
+});
+
+$app->get('/login', function () use ($container) {
+
+	// Create new Acme\Authentication instance
+	$auth = $container->make('auth');
+
+	// Validate the user credentials
+	if ($auth->verifyLogin('username', 'password')) {
+		echo 'User successfully logged in!';
+	}
+});
+
+$app->get('/articles', function () use ($container) {
+
+	// Create new Acme\Database instance
+	$database = $container->make('database');
+
+	// Select all articles from the database
+	$articles = $database->select('SELECT * FROM articles ORDER BY title');
+
+	// Display the articles
+	foreach ($articles as $article) {
+		echo '<a href="#">' . $article['title'] . '</a><br>';
+	}
+});
+
+// Example of automatic resolution, where the container automatically
+// creates an instance of the requested controller, including all
+// of its class dependencies
+$app->get('/automatic-resolution', array($container->make('Acme\Controller'), 'home'));
+
+$app->run();

--- a/public/container/libraries/Authentication.php
+++ b/public/container/libraries/Authentication.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme;
+
+class Authentication
+{
+	public function verifyLogin($username, $password)
+	{
+		return $username === 'username' and $password === 'password';
+	}
+}

--- a/public/container/libraries/Controller.php
+++ b/public/container/libraries/Controller.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Acme;
+
+class Controller
+{
+	private $database;
+	private $template;
+
+	public function __construct(\Acme\Database $database, \Acme\Template $template)
+	{
+		$this->database = $database;
+		$this->template = $template;
+	}
+
+	public function home()
+	{
+		echo $this->template->render('home');
+	}
+}

--- a/public/container/libraries/Database.php
+++ b/public/container/libraries/Database.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Acme;
+
+class Database
+{
+	public function select($query)
+	{
+		return array(
+			array('title' => 'Example article title'),
+			array('title' => 'Another example article title')
+		);
+	}
+}

--- a/public/container/libraries/Mailer.php
+++ b/public/container/libraries/Mailer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme;
+
+class Mailer
+{
+	public function send()
+	{
+		return true;
+	}
+}

--- a/public/container/libraries/Template.php
+++ b/public/container/libraries/Template.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Acme;
+
+class Template
+{
+	public function render($page)
+	{
+		return 'Rendered the page: "' . $page . '"';
+	}
+}


### PR DESCRIPTION
Using the Illuminate/Container outside of Laravel is actually quite easy. However, since this is a more advanced topic, giving simple/beginner examples is a little challenging. I used some mock classes to help illustrate both how to use the IoC container, and in what situations it might make sense to do so.

When using Slim route callbacks, the container can quickly start looking like a service locator. To help prevent confusion here, I also gave a controller example that uses automatic class resolution.

Finally, as discussed on Twitter, I've split this example into two sections: "Bootstrap" and "Routes".
