### PR TITLE
[Blade] Remove extra compiler argument

### DIFF
--- a/components/view/index.php
+++ b/components/view/index.php
@@ -37,8 +37,8 @@ $app->get('/', function () {
     $viewResolver = new EngineResolver;
     $bladeCompiler = new BladeCompiler($filesystem, $pathToCompiledTemplates);
 
-    $viewResolver->register('blade', function () use ($bladeCompiler, $filesystem) {
-        return new CompilerEngine($bladeCompiler, $filesystem);
+    $viewResolver->register('blade', function () use ($bladeCompiler) {
+        return new CompilerEngine($bladeCompiler);
     });
 
     $viewResolver->register('php', function () {


### PR DESCRIPTION
This confused one of our devs for a while, The compiler engine only accepts 1 arg.  
https://github.com/laravel/framework/blob/5.6/src/Illuminate/View/Engines/CompilerEngine.php#L31