### PR TITLE
add beanstalkd to queue component

### DIFF
--- a/components/queue/composer.json
+++ b/components/queue/composer.json
@@ -5,6 +5,7 @@
         "filp/whoops": "1.1.2",
         "illuminate/queue": "~5.5.0",
         "illuminate/events": "~5.5.0",
-        "illuminate/redis": "~5.5.0"
+        "illuminate/redis": "~5.5.0",
+        "pda/pheanstalk": "^3.1"
     }
 }


### PR DESCRIPTION
Builds upon #76 by adding beanstalkd as a connection.

Figured out it was my firewall that was blocking beanstalkd, so once I got that figure out it was really easy.

Thought about putting the worker in a container binding, but decided against it as I thought it was better to show how to create the worker in the context of the endpoint. If you have other thoughts on this, I can change it.

fixes #85