### PR TITLE
Component update for Laravel 5.5: Container

### DIFF
--- a/components/container/composer.json
+++ b/components/container/composer.json
@@ -3,6 +3,6 @@
         "slim/slim": "2.*",
         "zeuxisoo/slim-whoops": "~0.2.0",
         "filp/whoops": "1.1.2",
-        "illuminate/container": "~5.1.0"
+        "illuminate/container": "~5.5.0"
     }
 }

--- a/components/container/readme.md
+++ b/components/container/readme.md
@@ -4,7 +4,7 @@
 
 # Container
 
-This component shows how to use Laravel's [Container](https://laravel.com/docs/5.1/container) features in non-Laravel applications.
+This component shows how to use Laravel's [Container](https://laravel.com/docs/5.5/container) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve a web site locally showing the output of the `index.php` file.


### PR DESCRIPTION
update illuminate/container to `~5.5.0`, in composer.json
all examples tested with latest version of illuminate/container, v5.5.44

resolves #74 https://github.com/mattstauffer/Torch/issues/74