### PR TITLE
Component/Container: Add example, utilize composer psr-4 autoloader

### DIFF
--- a/components/container/composer.json
+++ b/components/container/composer.json
@@ -4,5 +4,8 @@
         "zeuxisoo/slim-whoops": "~0.2.0",
         "filp/whoops": "1.1.2",
         "illuminate/container": "~5.5.0"
+    },
+    "autoload": {
+        "psr-4": {"Acme\\": "libraries/"}
     }
 }

--- a/components/container/composer.json
+++ b/components/container/composer.json
@@ -3,6 +3,6 @@
         "slim/slim": "2.*",
         "zeuxisoo/slim-whoops": "~0.2.0",
         "filp/whoops": "1.1.2",
-        "illuminate/container": "~5.1.0"
+        "illuminate/container": "~5.5.0"
     }
 }

--- a/components/container/index.php
+++ b/components/container/index.php
@@ -50,6 +50,8 @@ $container->singleton('database', function ($container) {
 $auth = new Acme\Authentication;
 $container->instance('auth', $auth);
 
+// Bind an interface to a given implementation. 
+$container->bind('Acme\Contracts\NotifyUser', 'Acme\TextMessageNotification');
 
 /*
 |--------------------------------------------------------------------------
@@ -109,5 +111,15 @@ $app->get('/articles', function () use ($container) {
 // creates an instance of the requested controller, including all
 // of its class dependencies
 $app->get('/automatic-resolution', [$container->make('Acme\Controller'), 'home']);
+
+// A NotifyUser interface is bound in the container. 
+// Whenever an implementation is needed
+// Illuminate/Container resolves 
+// the concrete implemention.
+$app->get('/interface-to-implementation', function () use ($container) {
+
+    $notification = $container->make('Acme\Contracts\NotifyUser');
+    $notification->sendNotification('Somebody hit the url!');    
+});
 
 $app->run();

--- a/components/container/index.php
+++ b/components/container/index.php
@@ -22,11 +22,6 @@
 // Include project libraries, including a number of mock
 // examples of common, real-world services
 require_once 'vendor/autoload.php';
-require_once 'libraries/Authentication.php';
-require_once 'libraries/Controller.php';
-require_once 'libraries/Database.php';
-require_once 'libraries/Mailer.php';
-require_once 'libraries/Template.php';
 
 // Create new IoC Container instance
 $container = new Illuminate\Container\Container;

--- a/components/container/libraries/Contracts/NotifyUser.php
+++ b/components/container/libraries/Contracts/NotifyUser.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Acme\Contracts;
+
+interface NotifyUser
+{
+    public function sendNotification($message);
+}

--- a/components/container/libraries/TextMessageNotification.php
+++ b/components/container/libraries/TextMessageNotification.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Acme;
+
+use Acme\Contracts\NotifyUser;
+
+class TextMessageNotification implements NotifyUser
+{
+    public function sendNotification($message)
+    {
+        echo "Your text message notification: $message";
+    }  
+}

--- a/components/container/readme.md
+++ b/components/container/readme.md
@@ -4,7 +4,7 @@
 
 # Container
 
-This component shows how to use Laravel's [Container](https://laravel.com/docs/5.1/container) features in non-Laravel applications.
+This component shows how to use Laravel's [Container](https://laravel.com/docs/5.5/container) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve a web site locally showing the output of the `index.php` file.


### PR DESCRIPTION
utilize composer psr-4 auto-loading for all container/component examples
add a new example for container component: bind an interface to an implementation

this PR also updates illuminate/container dependency to `~5.5.0` in `components/container/composer.json` flie.

--> means if this one merges: PR #99 is obsolete
