### PR TITLE
[Queue] - bind Dispatcher for use in Job Failure

### DIFF
--- a/components/queue/index.php
+++ b/components/queue/index.php
@@ -4,6 +4,7 @@ use Illuminate\Queue\Worker;
 use Illuminate\Redis\RedisManager;
 use Illuminate\Container\Container;
 use Illuminate\Queue\WorkerOptions;
+use Illuminate\Events\Dispatcher;
 use Illuminate\Events\EventServiceProvider;
 use Illuminate\Queue\Capsule\Manager as Queue;
 use Illuminate\Contracts\Debug\ExceptionHandler;
@@ -39,9 +40,11 @@ class App extends Container
 }
 
 // BOOTSTRAP-------------------------------------------------------------------
-$container = new App;
+$container = App::getInstance();
 
 (new EventServiceProvider($container))->register();
+
+$container->instance('Illuminate\Contracts\Events\Dispatcher', new Dispatcher($container));
 
 $container->bind('redis', function () {
     return new RedisManager('predis', [


### PR DESCRIPTION
When a job fails, an exception is thrown because a `Dispatcher` could not be resolved from the container.  Creating the container with `getInstance()` and binding a Dispatcher object to the Dispatcher interface resolves this issue.