### PR TITLE
Component updates for Laravel 6.0: Container

### DIFF
--- a/components/container/composer.json
+++ b/components/container/composer.json
@@ -3,7 +3,7 @@
         "slim/slim": "2.*",
         "zeuxisoo/slim-whoops": "~0.2.0",
         "filp/whoops": "1.1.2",
-        "illuminate/container": "~5.5.0"
+        "illuminate/container": "~6.0"
     },
     "autoload": {
         "psr-4": {"Acme\\": "libraries/"}

--- a/components/container/readme.md
+++ b/components/container/readme.md
@@ -4,7 +4,7 @@
 
 # Container
 
-This component shows how to use Laravel's [Container](https://laravel.com/docs/5.5/container) features in non-Laravel applications.
+This component shows how to use Laravel's [Container](https://laravel.com/docs/6.0/container) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve a web site locally showing the output of the `index.php` file.


### PR DESCRIPTION
Closes #107 

Update the Container Component to Laravel 6.0.

All of the routes were checked, they worked as intended.