### PR TITLE
Component updates for Laravel 6.0: Artisan Console

### DIFF
--- a/components/artisan/composer.json
+++ b/components/artisan/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "illuminate/console": "^5.5",
-        "illuminate/events": "^5.5"
+        "illuminate/console": "^6.0",
+        "illuminate/events": "^6.0"
     },
     "autoload": {
         "classmap": ["commands"]

--- a/components/artisan/readme.md
+++ b/components/artisan/readme.md
@@ -4,7 +4,7 @@
 
 # Console
 
-This component shows how to use Laravel's [Artisan Console](https://laravel.com/docs/5.5/artisan) features in non-Laravel applications.
+This component shows how to use Laravel's [Artisan Console](https://laravel.com/docs/6.0/artisan) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve console application.


### PR DESCRIPTION
Closes #108 

Update the Artisan Console Component to Laravel 6.0.

Tested some commands after upgrading - everything worked as expected.