### PR TITLE
Component updates for Laravel 6.0: Cache

### DIFF
--- a/components/cache/composer.json
+++ b/components/cache/composer.json
@@ -3,10 +3,10 @@
         "slim/slim": "3.*",
         "zeuxisoo/slim-whoops": "0.6.*",
         "filp/whoops": "2.1.10",
-        "illuminate/cache": "~5.5.0",
-        "illuminate/container": "~5.5.0",
-        "illuminate/filesystem": "~5.5.0",
-        "illuminate/redis": "~5.5.0",
+        "illuminate/cache": "~6.0",
+        "illuminate/container": "~6.0",
+        "illuminate/filesystem": "~6.0",
+        "illuminate/redis": "~6.0",
         "predis/predis": "^1.0"
     }
 }

--- a/components/cache/index.php
+++ b/components/cache/index.php
@@ -77,7 +77,7 @@ $app->get('/redis', function () {
         ]
     ];
 
-    $container['redis'] = new RedisManager('predis', $container['config']['database.redis']);
+    $container['redis'] = new RedisManager($container, 'predis', $container['config']['database.redis']);
 
     $cacheManager = new CacheManager($container);
 

--- a/components/cache/readme.md
+++ b/components/cache/readme.md
@@ -4,7 +4,7 @@
 
 # Cache
 
-This component shows how to use Laravel's [Cache](https://laravel.com/docs/5.5/cache) features in non-Laravel applications.
+This component shows how to use Laravel's [Cache](https://laravel.com/docs/6.0/cache) features in non-Laravel applications.
 
 ## Usage
 


### PR DESCRIPTION
Closes #109 

Update the Cache Component to Laravel 6.0.

All routes and functionalities work as expected when updated.