### PR TITLE
Component updates for Laravel 6.0: Encryption

### DIFF
--- a/components/encryption/composer.json
+++ b/components/encryption/composer.json
@@ -3,6 +3,6 @@
         "slim/slim": "3.*",
         "zeuxisoo/slim-whoops": "0.6.*",
         "filp/whoops": "2.1.10",
-        "illuminate/encryption": "~5.5.0"
+        "illuminate/encryption": "~6.0"
     }
 }

--- a/components/encryption/readme.md
+++ b/components/encryption/readme.md
@@ -4,7 +4,7 @@
 
 # Encryption
 
-This component shows how to use Laravel's [Encryption](https://laravel.com/docs/5.5/encryption) features in non-Laravel applications.
+This component shows how to use Laravel's [Encryption](https://laravel.com/docs/6.0/encryption) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve a web site locally showing the output of the `index.php` file.


### PR DESCRIPTION
Closes #112 

Update the Encryption Component to Laravel 6.0.

Tested after upgrading - everything worked as expected.