### PR TITLE
Component updates for Laravel 6.0: Events

### DIFF
--- a/components/events/composer.json
+++ b/components/events/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "illuminate/events": "^5.5"
+        "illuminate/events": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/components/events/index.php
+++ b/components/events/index.php
@@ -2,7 +2,7 @@
 
 include 'vendor/autoload.php';
 
-/**
+/*
  * Illuminate/events
  *
  * @source https://github.com/illuminate/events
@@ -20,4 +20,4 @@ $dispatcher->listen([UserHasRegisteredEvent::class], SendWelcomingEmail::class);
 
 // Firing the event
 
-$dispatcher->fire(new UserHasRegisteredEvent("example"));
+$dispatcher->dispatch(new UserHasRegisteredEvent('example'));

--- a/components/events/readme.md
+++ b/components/events/readme.md
@@ -4,7 +4,7 @@
 
 # Events
 
-This component shows how to use Laravel's [Events](https://laravel.com/docs/5.5/events) features in non-Laravel applications.
+This component shows how to use Laravel's [Events](https://laravel.com/docs/6.0/events) features in non-Laravel applications.
 
 ## Usage
 From this directory, run the following to serve a web site locally showing the output of the `index.php` file.


### PR DESCRIPTION
Closes #113 

Update the Events Component to Laravel 6.0.

Tested after upgrading - everything worked as expected.