### PR TITLE
Use env() helper by invoking Dotenv\Dotenv directly

### DIFF
--- a/components/support/.env
+++ b/components/support/.env
@@ -1,0 +1,2 @@
+ENV_TEST_1=42
+ENV_TEST_2="forty-two"

--- a/components/support/composer.json
+++ b/components/support/composer.json
@@ -4,6 +4,7 @@
         "illuminate/support": "^8.0",
         "slim/psr7": "1.2.*",
         "slim/slim": "4.*",
-        "zeuxisoo/slim-whoops": "0.7.*"
+        "zeuxisoo/slim-whoops": "0.7.*",
+        "vlucas/phpdotenv": "^5.3"
     }
 }

--- a/components/support/index.php
+++ b/components/support/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Env;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\Pluralizer;
@@ -26,10 +27,14 @@ require_once 'vendor/autoload.php';
  // Instantiate App
 $app = AppFactory::create();
 
+// Intantiate, providing path to your .env file
+$dotenv = Dotenv\Dotenv::createImmutable('.');
+$env = $dotenv->load();
+
 // Middleware
 $app->add(new WhoopsMiddleware(['enable' => true]));
 
-$app->get('/', function (Request $request, Response $response) {
+$app->get('/', function (Request $request, Response $response) use ($env) {
     // MessageBag init
     $messageBag = new MessageBag;
 
@@ -115,6 +120,16 @@ $app->get('/', function (Request $request, Response $response) {
     $response->getBody()->write("MessageBag ({$messageBag->count()})\n");
     foreach ($messageBag->all() as $message) {
         $response->getBody()->write(" - $message\n");
+    }
+
+    $response->getBody()->write('</pre><hr>');
+
+    // Env
+    $response->getBody()->write('<h2>Env</h2>');
+    $response->getBody()->write('<pre>');
+
+    foreach ($env as $k => $v) {
+        $response->getBody()->write("{$k}: " . env($k) . "\n");
     }
 
     return $response;


### PR DESCRIPTION
Hey

I've provided an example of how to use the `env()` helper in conjunction with direct leverage of the Dotenv\Dotenv library. Unfortunately, the values aren't accessible with `Illuminate\Support\Env`; not sure what the missing bit is.

That said, maybe it's not important. IIRC, laravel folks say to only rely on app environment variables in the config files.

Thoughts?